### PR TITLE
Updated camera feed offset layout method

### DIFF
--- a/examples/CameraVision/CameraVision/VisionController.swift
+++ b/examples/CameraVision/CameraVision/VisionController.swift
@@ -22,10 +22,7 @@ class VisionController: UIViewController {
     
     private var _takePhotoObserver: NSKeyValueObservation?
 
-    var test: UIView!
-    var dxConstraint: NSLayoutConstraint!
-    var dyConstraint: NSLayoutConstraint!
-
+    
     override func viewDidLoad() {
         
         // call base implementation
@@ -50,34 +47,6 @@ class VisionController: UIViewController {
                 ? 0.5
                 : 1.0
         }
-        
-        test = UIView()
-        test.translatesAutoresizingMaskIntoConstraints = false
-        test.backgroundColor = UIColor.clear
-        view.addSubview(test)
-       
-        // bind constraints
-        dxConstraint = NSLayoutConstraint(item: test, attribute: .centerX,
-                                           relatedBy: .equal,
-                                           toItem: view, attribute: .centerX,
-                                           multiplier: 1.0, constant: 0.0)
-        dyConstraint = NSLayoutConstraint(item: test, attribute: .centerY,
-                                           relatedBy: .equal,
-                                           toItem: view, attribute: .centerY ,
-                                           multiplier: 1.0, constant: 0.0)
-        view.addConstraints([
-            dxConstraint,
-            dyConstraint,
-            NSLayoutConstraint(item: test, attribute: .width,
-                                           relatedBy: .equal,
-                                           toItem: view, attribute: .width ,
-                                           multiplier: 1.0, constant: 0.0),
-            NSLayoutConstraint(item: test, attribute: .height,
-                                           relatedBy: .equal,
-                                           toItem: view, attribute: .height ,
-                                           multiplier: 1.0, constant: 0.0)
-        ])
-        view.bringSubviewToFront(test)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -114,11 +83,6 @@ class VisionController: UIViewController {
     }
     
     @IBAction func toggleCameraPosition() {
-        
-        if (dyConstraint != nil) {
-            dyConstraint.constant = -51
-            test.updateConstraints()
-        }
         
         // determine new camera position
         let cameraPosition = _cameraFeed.cameraPosition == .front


### PR DESCRIPTION
This change updates the way the offset is calculated when the camera feed view updates its layout.  Added async closure for calculating potential previewLayer. If layer before and after the async match, assume UI updates are complete and calculate correct offset, otherwise, flag UI layout to be calculated again and perform same check until layers before/after are matching 